### PR TITLE
fix: release

### DIFF
--- a/src/stories/index.stories.tsx
+++ b/src/stories/index.stories.tsx
@@ -1,4 +1,4 @@
-import {Meta, StoryFn} from '@storybook/react';
+import type {Meta, StoryFn} from '@storybook/react';
 import React from 'react';
 
 import {FIXED, LEGACY_THEME, MOVING, YCLOUD_THEME} from '../lib/constants';
@@ -6,10 +6,12 @@ import {FIXED, LEGACY_THEME, MOVING, YCLOUD_THEME} from '../lib/constants';
 import ExampleDT100, {defaultProps} from './Example/Example';
 import {ResizeableTable} from './Resizeable/Resizeable';
 
-export default {
+const meta: Meta<typeof ExampleDT100> = {
     title: 'React Data Table',
     component: ExampleDT100,
-} as Meta<typeof ExampleDT100>;
+};
+
+export default meta;
 
 const templateArgTypes = {
     stickyHeadValues: {
@@ -27,12 +29,12 @@ const templateArgTypes = {
 
 const Template: StoryFn<typeof ExampleDT100> = (args) => <ExampleDT100 {...args} />;
 
-export const Default = Template.bind({});
+export const Default: StoryFn<typeof ExampleDT100> = Template.bind({});
 Default.args = defaultProps;
 Default.argTypes = templateArgTypes;
 
 const ResizeableTemplate: StoryFn<typeof ResizeableTable> = (args) => <ResizeableTable {...args} />;
 
-export const Resizeable = ResizeableTemplate.bind({});
-Default.args = {theme: YCLOUD_THEME};
-Default.argTypes = templateArgTypes;
+export const Resizeable: StoryFn<typeof ResizeableTable> = ResizeableTemplate.bind({});
+Resizeable.args = {theme: YCLOUD_THEME};
+Resizeable.argTypes = templateArgTypes;


### PR DESCRIPTION
```
> @gravity-ui/react-data-table@2.2.0 prepublishOnly
> npm run build


> @gravity-ui/react-data-table@2.2.0 build
> npm run build:clean && npm run build:compile && npm run build:copy


> @gravity-ui/react-data-table@2.2.0 build:clean
> rm -rf build


> @gravity-ui/react-data-table@2.2.0 build:compile
> tsc

src/stories/index.stories.tsx:9:1 - error TS2742: The inferred type of 'default' cannot be named without a reference to '@storybook/react/node_modules/@storybook/types'. This is likely not portable. A type annotation is necessary.

 9 export default {
   ~~~~~~~~~~~~~~~~
10     title: 'React Data Table',
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
11     component: ExampleDT100,
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
12 } as Meta<typeof ExampleDT100>;
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/stories/index.stories.tsx:30:14 - error TS2742: The inferred type of 'Default' cannot be named without a reference to '@storybook/react/node_modules/@storybook/types'. This is likely not portable. A type annotation is necessary.

30 export const Default = Template.bind({});
                ~~~~~~~

src/stories/index.stories.tsx:36:14 - error TS2742: The inferred type of 'Resizeable' cannot be named without a reference to '@storybook/react/node_modules/@storybook/types'. This is likely not portable. A type annotation is necessary.

36 export const Resizeable = ResizeableTemplate.bind({});
                ~~~~~~~~~~


Found 3 errors in the same file, starting at: src/stories/index.stories.tsx:9

npm error code 1
npm error path /home/runner/work/react-data-table/react-data-table
npm error command failed
npm error command sh -c npm run build
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-02-14T08_28_46_[648](https://github.com/gravity-ui/react-data-table/actions/runs/13325357705/job/37217322200#step:2:665)Z-debug-0.log
Error: Process completed with exit code 1.
```